### PR TITLE
Add difficulty settings (Easy/Normal/Hard) (#2)

### DIFF
--- a/run.py
+++ b/run.py
@@ -119,7 +119,7 @@ class InputController:
         col, row = self.pos_to_grid(pos[0], pos[1])
         if col == -1:
             return
-        
+
         game = self.game
 
         if button == config.mouse_left:
@@ -129,11 +129,11 @@ class InputController:
                 game.started = True
                 game.start_ticks_ms = pygame.time.get_ticks()
             game.board.reveal(col, row)
-    
+
         elif button == config.mouse_right:
             game.highlight_targets.clear()
             game.board.toggle_flag(col, row)
-               
+
         elif button == config.mouse_middle:
             neighbors = game.board.neighbors(col, row)
             game.highlight_targets = {
@@ -141,8 +141,9 @@ class InputController:
                 for (nc, nr) in neighbors
                 if not game.board.cells[game.board.index(nc, nr)].state.is_revealed
             }
-            
+
             game.highlight_until_ms = pygame.time.get_ticks() + config.highlight_duration_ms
+
 
 class Game:
     """Main application object orchestrating loop and high-level state."""
@@ -150,6 +151,11 @@ class Game:
     def __init__(self):
         pygame.init()
         pygame.display.set_caption(config.title)
+
+        self.difficulty = getattr(config, "default_difficulty", "normal")
+        if hasattr(config, "apply_difficulty"):
+            config.apply_difficulty(self.difficulty)
+
         self.screen = pygame.display.set_mode(config.display_dimension)
         self.clock = pygame.time.Clock()
         self.board = Board(config.cols, config.rows, config.num_mines)
@@ -170,6 +176,17 @@ class Game:
         self.started = False
         self.start_ticks_ms = 0
         self.end_ticks_ms = 0
+
+    def set_difficulty(self, name: str) -> None:
+        """Change difficulty (board size + mines), resize window, and reset."""
+        if not hasattr(config, "difficulty_presets") or name not in config.difficulty_presets:
+            return
+        self.difficulty = name
+        config.apply_difficulty(name)
+
+        self.screen = pygame.display.set_mode(config.display_dimension)
+        self.renderer.screen = self.screen
+        self.reset()
 
     def _elapsed_ms(self) -> int:
         """Return elapsed time in milliseconds (stops when game ends)."""
@@ -218,6 +235,12 @@ class Game:
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_r:
                     self.reset()
+                elif event.key == pygame.K_1:
+                    self.set_difficulty("easy")
+                elif event.key == pygame.K_2:
+                    self.set_difficulty("normal")
+                elif event.key == pygame.K_3:
+                    self.set_difficulty("hard")
             if event.type == pygame.MOUSEBUTTONDOWN:
                 self.input.handle_mouse(event.pos, event.button)
         if (self.board.game_over or self.board.win) and self.started and not self.end_ticks_ms:


### PR DESCRIPTION
Fixes #2

**개요**
- 난이도(Easy/Normal/Hard)에 따라 게임 판의 가로×세로 크기와 지뢰 수가 변경되도록 기능을 추가했습니다.

**변경 사항**
- config.py
난이도 프리셋(difficulty_presets)과 기본 난이도(default_difficulty)를 추가했습니다.
난이도 적용 시 cols/rows/num_mines와 창 크기(display_dimension)가 함께 갱신되도록 apply_difficulty() / recompute_dimensions()를 추가했습니다.

- run.py
게임 시작 시 기본 난이도를 적용하도록 초기화 로직을 추가했습니다.
난이도 변경 시 창 크기를 재설정하고 보드를 리셋하도록 set_difficulty()를 추가했습니다.
단축키로 난이도를 변경할 수 있도록 키 입력 처리를 추가했습니다. (1=easy, 2=normal, 3=hard)

**테스트**
실행 후 1/2/3 키 입력으로 난이도가 변경되며, 보드 크기와 지뢰 수가 각각 프리셋에 맞게 바뀌는지 확인 <- 위쪽 숫자 키패드에서 입력
난이도 변경 후 게임이 정상적으로 새 보드로 리셋되는지 확인